### PR TITLE
Get type code from actual value

### DIFF
--- a/modules/deploy/DeployPackage/Deploy-SSISIspac.ps1
+++ b/modules/deploy/DeployPackage/Deploy-SSISIspac.ps1
@@ -204,7 +204,7 @@ function Deploy-SSISIspac {
                 }
                 # TODO: handle sensitive variables ($false -> $true)
                 # Constructor args: variable name, typeCode, default value, sensitivity, description
-                $ssisEnvironment.Variables.Add($variableName, $variableName.GetTypeCode(), $variableValue, $false, $variableName)
+                $ssisEnvironment.Variables.Add($variableName, $variableValue.GetTypeCode(), $variableValue, $false, $variableName)
             }
             $ssisEnvironment.Create()
         }


### PR DESCRIPTION
SSIS variable should be created using type of actual value not $variableName which always returns String (because it is name of the variable and a key in parameters dictionary defined in $Tokens)