### PR TITLE
Fixed wildcard overriding in 7Zip

### DIFF
--- a/core/Copy-FilesToRemoteServer/Copy-FilesToRemoteServer.ps1
+++ b/core/Copy-FilesToRemoteServer/Copy-FilesToRemoteServer.ps1
@@ -190,6 +190,7 @@ function Copy-FilesToRemoteServer {
 
             $zipParams = @{
                 Path = $Path
+                DestinationZipPath = $Destination
                 OutputFile = $tempZip
                 Include = $Include
                 IncludeRecurse = $IncludeRecurse
@@ -198,7 +199,7 @@ function Copy-FilesToRemoteServer {
             }
 
             if (!$BlueGreenEnvVariableName -and $Path.Count -gt 1) { 
-                New-Zip @zipParams -DestinationZipPath $Destination
+                New-Zip @zipParams
                 $isStructuredZip = $true
             } else {
                 New-Zip @zipParams -Try7Zip

--- a/core/Copy-FilesToRemoteServer/Copy-FilesToRemoteServer.ps1
+++ b/core/Copy-FilesToRemoteServer/Copy-FilesToRemoteServer.ps1
@@ -190,7 +190,6 @@ function Copy-FilesToRemoteServer {
 
             $zipParams = @{
                 Path = $Path
-                DestinationZipPath = $Destination
                 OutputFile = $tempZip
                 Include = $Include
                 IncludeRecurse = $IncludeRecurse
@@ -199,7 +198,7 @@ function Copy-FilesToRemoteServer {
             }
 
             if (!$BlueGreenEnvVariableName -and $Path.Count -gt 1) { 
-                New-Zip @zipParams
+                New-Zip @zipParams -DestinationZipPath $Destination
                 $isStructuredZip = $true
             } else {
                 New-Zip @zipParams -Try7Zip

--- a/core/zip/Compress-With7Zip.Tests.ps1
+++ b/core/zip/Compress-With7Zip.Tests.ps1
@@ -1,0 +1,129 @@
+<#
+The MIT License (MIT)
+
+Copyright (c) 2015 Objectivity Bespoke Software Specialists
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+#>
+
+Import-Module -Name "$PSScriptRoot\..\..\PSCI.psd1" -Force
+
+Describe -Tag "PSCI.unit" "Compress-With7Zip" {
+
+    InModuleScope PSCI.core {
+        
+        function New-TestDirStructure {
+            Remove-Item -LiteralPath 'testDir' -Force -Recurse -ErrorAction SilentlyContinue
+            Remove-Item -LiteralPath 'testDirOut' -Force -Recurse -ErrorAction SilentlyContinue
+
+            New-Item -Path 'testDir\testDir1\testDir11' -ItemType Directory -Force
+            New-Item -Path 'testDir\testDir1\testDir2' -ItemType Directory -Force
+            New-Item -Path 'testDir\testDir2' -ItemType Directory -Force
+            New-Item -Path 'testDir\testDir3' -ItemType Directory -Force
+
+            New-Item -Path 'testDir\testDir1\testDir11\testFile11' -ItemType File -Value 'testFile11' -Force
+            New-Item -Path 'testDir\testDir1\testDir2\testFile12' -ItemType File -Value 'testFile12' -Force
+            New-Item -Path 'testDir\testDir2\testFile2' -ItemType File -Value 'testFile2' -Force
+            1..11 | % { New-Item -Path "testDir\testDir3\testFile$_" -ItemType File -Value 'testFile$_' -Force }
+        }
+
+        function Remove-TestDirStructure {
+            Remove-Item -LiteralPath 'testDir' -Force -Recurse -ErrorAction SilentlyContinue
+            Remove-Item -LiteralPath 'testDirOut' -Force -Recurse -ErrorAction SilentlyContinue
+        }
+
+        Mock Write-Log { 
+            Write-Host $Message
+            if ($Critical) {
+                throw $Message
+            }
+        }
+
+        Mock Start-ExternalProcess {
+            Write-Host "Arguments passed to 7z: $ArgumentList"
+        }
+
+        Mock Get-PathTo7Zip {
+            return "7z.exe"
+        }
+
+        Context "when compressing" {
+            try {
+                New-TestDirStructure
+            
+                It "should properly compress single file" {
+                    Compress-With7Zip -PathsToCompress 'testFile' -OutputFile 'output.zip'
+
+                    Assert-MockCalled Start-ExternalProcess -Exactly 1 -ParameterFilter {
+                        $ArgumentList -eq 'a "output.zip" "testFile"'
+                    }
+                }
+
+                It "should properly compress directory by paths and includes" {
+                    Compress-With7Zip -PathsToCompress 'testDir' -Include @('testDir1', 'testDir2') -OutputFile 'output.zip'
+                    Assert-MockCalled Start-ExternalProcess -Exactly 1 -ParameterFilter {
+                        $ArgumentList -eq 'a "output.zip" "testDir" -i!testDir1 -i!testDir2'
+                    }
+                }
+
+                It "should properly compress directory by paths only" {
+                    Compress-With7Zip -PathsToCompress 'testDir' -OutputFile 'output.zip'
+                    Assert-MockCalled Start-ExternalProcess -Exactly 1 -ParameterFilter {
+                        $ArgumentList -eq 'a "output.zip" "testDir"'
+                    }
+                }
+
+                It "should properly compress directory by includes only" {
+                    Compress-With7Zip -Include @('testDir1', 'testDir2') -WorkingDirectory 'testDir' -OutputFile 'output.zip'
+                    Assert-MockCalled Start-ExternalProcess -Exactly 1 -ParameterFilter {
+                        $ArgumentList -eq 'a "output.zip"  -i!testDir1 -i!testDir2' `
+                        -and $WorkingDirectory -eq (Join-Path -Path (Get-Location | Select-Object -ExpandProperty Path) -ChildPath 'testDir')
+                    }
+                }
+
+                It "should properly compress single directory by paths" {
+                    Compress-With7Zip -PathsToCompress '*' -WorkingDirectory 'testDir' -OutputFile 'output.zip'
+
+                    Assert-MockCalled Start-ExternalProcess -Exactly 1 -ParameterFilter {
+                        $ArgumentList -eq 'a "output.zip" "*"' `
+                        -and $WorkingDirectory -eq (Join-Path -Path (Get-Location | Select-Object -ExpandProperty Path) -ChildPath 'testDir')
+                    }
+                }
+
+                It "should properly compress multiple directories by paths" {
+                    $manyDirectories = Get-ChildItem 'testDir\testDir3' -File
+
+                    Mock New-Item { return @{FullName='filelist.txt'} }
+
+                    Compress-With7Zip -PathsToCompress $manyDirectories -OutputFile 'output.zip'
+
+                    Assert-MockCalled New-Item -Exactly 1 -ParameterFilter {
+                        $Value -eq ($manyDirectories -join "`r`n")
+                    }
+
+                    Assert-MockCalled Start-ExternalProcess -Exactly 1 -ParameterFilter {
+                        $ArgumentList -eq 'a "output.zip" -i@"filelist.txt"'
+                    }
+                }
+            } finally {
+                Remove-TestDirStructure
+            }
+        }
+    }
+}

--- a/core/zip/Compress-With7Zip.ps1
+++ b/core/zip/Compress-With7Zip.ps1
@@ -66,7 +66,7 @@ function Compress-With7Zip {
     [CmdletBinding()]
     [OutputType([void])]
     param(
-        [Parameter(Mandatory=$true)]
+        [Parameter(Mandatory=$false)]
         [string[]]
         $PathsToCompress,
         
@@ -113,6 +113,10 @@ function Compress-With7Zip {
         $Quiet
     )
 
+    if (!$PathsToCompress -and !$Include) {
+        throw "At least one of parameters is required: PathsToCompress or Include."
+    }
+
     $cmdLine = New-Object System.Text.StringBuilder
 
     $7zipPath = Get-PathTo7Zip -FailIfNotFound
@@ -134,7 +138,9 @@ function Compress-With7Zip {
 
     [void]($cmdLine.Append("a $OutputFile "))
 
-    if ($PathsToCompress.Length -lt 10) {
+    if ($PathsToCompress.Length -eq 1 -and $PathsToCompress[0] -eq '*' -and $Include) {
+        #avoid overriding $Include filters with '*' wildcard
+    } elseif ($PathsToCompress.Length -lt 10) {
         $PathsToCompress = Add-QuotesToPaths $PathsToCompress
         [void]($cmdLine.Append(($PathsToCompress -join " ")))
         # Note: we should not use '-r' option as this is not standard recursion - it would instead search all <$Include> in current directory recursively

--- a/core/zip/Compress-With7Zip.ps1
+++ b/core/zip/Compress-With7Zip.ps1
@@ -137,8 +137,7 @@ function Compress-With7Zip {
     $OutputFile = Add-QuotesToPaths $OutputFile
 
     [void]($cmdLine.Append("a $OutputFile "))
-
-    if ($PathsToCompress.Length -eq 1 -and $PathsToCompress[0] -eq '*' -and $Include) {
+    if (!$PathsToCompress -or ($PathsToCompress.Length -eq 1 -and $PathsToCompress[0] -eq '*' -and $Include)) {
         #avoid overriding $Include filters with '*' wildcard
     } elseif ($PathsToCompress.Length -lt 10) {
         $PathsToCompress = Add-QuotesToPaths $PathsToCompress
@@ -190,7 +189,11 @@ function Compress-With7Zip {
     }
 
     try { 
-        Write-Log -_Debug "Invoking 7zip at directory '$WorkingDirectory' ($($PathsToCompress.Count) path(s))."
+        $includes = '(None)'
+        if($Include -and $Include.Length -gt 0) {
+            $includes = $Include -join ","
+        }
+        Write-Log -_Debug "Invoking 7zip at directory '$WorkingDirectory' ($($PathsToCompress.Count) path(s)) including wildcards: $includes."
         [void](Start-ExternalProcess -Command $7zipPath -ArgumentList ($cmdLine.ToString()) -WorkingDirectory $WorkingDirectory -Quiet:$Quiet)
     } finally {
         if ($fileList -and (Test-Path -LiteralPath $fileList)) {


### PR DESCRIPTION
Omit * wildcard when $Include parameter is provided to compress only specified paths.